### PR TITLE
ゲストログイン機能　エラー修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,11 @@ class User < ApplicationRecord
   def self.guest
     find_or_create_by!(email: 'guest@guest.com') do |user|
       user.password = SecureRandom.urlsafe_base64
+      user.user_name = "ゲスト"
+      user.last_name = "ゲスト"
+      user.first_name = "ユーザー"
+      user.last_name_kana = "ゲスト"
+      user.first_name_kana = "ユーザー"
     end
   end
 


### PR DESCRIPTION
ゲストユーザー未登録で「ゲストユーザーログイン」を行うとエラーになるのを解決。
null falseのカラムを設定。